### PR TITLE
Add colon suffix to signup emoticon

### DIFF
--- a/slack-me/handler.py
+++ b/slack-me/handler.py
@@ -25,7 +25,7 @@ def handle(req):
             elif "sofia" in msg:
                 emoticons = ":flag-bg: :flag-bg: :flag-bg:"
             elif "signup" in msg:
-                emoticons = ":+1"
+                emoticons = ":+1:"
             
             ret = { "text": qs["user_name"][0] + " sent a message with a length of... '" + str(len(req)) + "' " + emoticons }
             return json.dumps(ret)


### PR DESCRIPTION
Fixing a typo where the signup emoticon was missing a trailing colon.

Signed-off-by: Richard Gee <richard@technologee.co.uk>